### PR TITLE
Deactivate User Profile

### DIFF
--- a/SQL/01_TabloidMVC_Create_DB.sql
+++ b/SQL/01_TabloidMVC_Create_DB.sql
@@ -35,6 +35,7 @@ CREATE TABLE [UserProfile] (
   [CreateDateTime] datetime NOT NULL,
   [ImageLocation] nvarchar(255),
   [UserTypeId] integer NOT NULL,
+  [IsDeactivated] bit NOT NULL DEFAULT(0)
 
   CONSTRAINT [FK_User_UserType] FOREIGN KEY ([UserTypeId]) REFERENCES [UserType] ([Id])
 )

--- a/SQL/02_TabloidMVC_Seed_Data.sql
+++ b/SQL/02_TabloidMVC_Seed_Data.sql
@@ -10,7 +10,7 @@ SET IDENTITY_INSERT [Category] ON
 INSERT INTO [Category] ([Id], [Name]) 
 VALUES (1, 'Technology'), (2, 'Close Magic'), (3, 'Politics'), (4, 'Science'), (5, 'Improv'), 
 	   (6, 'Cthulhu Sightings'), (7, 'History'), (8, 'Home and Garden'), (9, 'Entertainment'), 
-	   (10, 'Cooking'), (11, 'Music'), (12, 'Movies'), (13, 'Regrets');
+	   (10, 'Cooking'), (11, 'Music'), (12, 'Movies'), (13, 'Regrets'), (14, 'No Category');
 SET IDENTITY_INSERT [Category] OFF
 
 

--- a/SQL/02_TabloidMVC_Seed_Data.sql
+++ b/SQL/02_TabloidMVC_Seed_Data.sql
@@ -21,8 +21,8 @@ SET IDENTITY_INSERT [Tag] OFF
 
 SET IDENTITY_INSERT [UserProfile] ON
 INSERT INTO [UserProfile] (
-	[Id], [FirstName], [LastName], [DisplayName], [Email], [CreateDateTime], [ImageLocation], [UserTypeId])
-VALUES (1, 'Admina', 'Strator', 'admin', 'admin@example.com', SYSDATETIME(), NULL, 1);
+	[Id], [FirstName], [LastName], [DisplayName], [Email], [CreateDateTime], [ImageLocation], [UserTypeId], [IsDeactivated])
+VALUES (1, 'Admina', 'Strator', 'admin', 'admin@example.com', SYSDATETIME(), NULL, 1, 0);
 SET IDENTITY_INSERT [UserProfile] OFF
 
 SET IDENTITY_INSERT [Post] ON

--- a/TabloidMVC/Controllers/AccountController.cs
+++ b/TabloidMVC/Controllers/AccountController.cs
@@ -30,7 +30,7 @@ namespace TabloidMVC.Controllers
 
             if (userProfile == null)
             {
-                ModelState.AddModelError("Email", "Invalid email");
+                ModelState.AddModelError("Email", "Invalid email or user has been deactivated");
                 return View();
             }
 

--- a/TabloidMVC/Repositories/IUserProfileRepository.cs
+++ b/TabloidMVC/Repositories/IUserProfileRepository.cs
@@ -8,5 +8,6 @@ namespace TabloidMVC.Repositories
         UserProfile GetByEmail(string email);
         List<UserProfile> GetAll();
         UserProfile GetById(int id);
+        void Deactivate(int id);
     }
 }

--- a/TabloidMVC/Repositories/IUserProfileRepository.cs
+++ b/TabloidMVC/Repositories/IUserProfileRepository.cs
@@ -7,6 +7,7 @@ namespace TabloidMVC.Repositories
     {
         UserProfile GetByEmail(string email);
         List<UserProfile> GetAll();
+        List<UserProfile> GetDeactivated();
         UserProfile GetById(int id);
         void Deactivate(int id);
     }

--- a/TabloidMVC/Repositories/UserProfileRepository.cs
+++ b/TabloidMVC/Repositories/UserProfileRepository.cs
@@ -97,6 +97,24 @@ namespace TabloidMVC.Repositories
             }
         }
 
+        public void Deactivate(int id)
+        {
+            using (var conn = Connection)
+            {
+                conn.Open();
+                using (var cmd = conn.CreateCommand())
+                {
+                    cmd.CommandText = @"
+                            UPDATE UserProfile
+                                SET IsDeactivated = 1
+                            WHERE Id = @id";
+                    cmd.Parameters.AddWithValue("@id", id);
+
+                    cmd.ExecuteNonQuery();
+                }
+            }
+        }
+
         private UserProfile NewUserFromReader(SqlDataReader reader)
         {
             return new UserProfile()

--- a/TabloidMVC/Repositories/UserProfileRepository.cs
+++ b/TabloidMVC/Repositories/UserProfileRepository.cs
@@ -22,7 +22,8 @@ namespace TabloidMVC.Repositories
                               u.CreateDateTime, u.ImageLocation, u.UserTypeId,
                               ut.[Name] AS UserTypeName
                          FROM UserProfile u
-                              LEFT JOIN UserType ut ON u.UserTypeId = ut.id";
+                              LEFT JOIN UserType ut ON u.UserTypeId = ut.id
+                         WHERE u.IsDeactivated = 0";
 
                     SqlDataReader reader = cmd.ExecuteReader();
 
@@ -35,6 +36,34 @@ namespace TabloidMVC.Repositories
                     reader.Close();
 
                     return users;
+                }
+            }
+        }
+
+        public List<UserProfile> GetDeactivated()
+        {
+            using (SqlConnection conn = Connection)
+            {
+                conn.Open();
+                using (SqlCommand cmd = conn.CreateCommand())
+                {
+                    cmd.CommandText = @"
+                       SELECT u.id, u.FirstName, u.LastName, u.DisplayName, u.Email,
+                              u.CreateDateTime, u.ImageLocation, u.UserTypeId,
+                              ut.[Name] AS UserTypeName
+                         FROM UserProfile u
+                              LEFT JOIN UserType ut ON u.UserTypeId = ut.id
+                         WHERE u.IsDeactivated = 1";
+
+                    SqlDataReader reader = cmd.ExecuteReader();
+                    List<UserProfile> deactivatedUsers = new List<UserProfile>();
+                    while (reader.Read())
+                    {
+                        deactivatedUsers.Add(NewUserFromReader(reader));
+                    }
+
+                    reader.Close();
+                    return deactivatedUsers;
                 }
             }
         }
@@ -51,7 +80,7 @@ namespace TabloidMVC.Repositories
                               ut.[Name] AS UserTypeName
                          FROM UserProfile u
                               LEFT JOIN UserType ut ON u.UserTypeId = ut.id
-                        WHERE email = @email";
+                        WHERE email = @email AND u.IsDeactivated = 0";
                     cmd.Parameters.AddWithValue("@email", email);
 
                     UserProfile userProfile = null;

--- a/TabloidMVC/Views/UserProfile/Delete.cshtml
+++ b/TabloidMVC/Views/UserProfile/Delete.cshtml
@@ -1,0 +1,48 @@
+﻿@model TabloidMVC.Models.UserProfile
+
+@{
+    ViewData["Title"] = "Delete";
+}
+<div class="container mx-4 pt-5">
+    <h3>Are you sure you want to deactivate user <b>@Model.DisplayName</b>?</h3>
+    <div>
+        <hr />
+        <dl class="row">
+            <dt class="col-sm-2">
+                @Html.DisplayNameFor(model => model.DisplayName)
+            </dt>
+            <dd class="col-sm-10">
+                @Html.DisplayFor(model => model.DisplayName)
+            </dd>
+            <dt class="col-sm-2">
+                @Html.DisplayNameFor(model => model.FullName)
+            </dt>
+            <dd class="col-sm-10">
+                @Html.DisplayFor(model => model.FullName)
+            </dd>
+            <dt class="col-sm-2">
+                @Html.DisplayNameFor(model => model.Email)
+            </dt>
+            <dd class="col-sm-10">
+                @Html.DisplayFor(model => model.Email)
+            </dd>
+            <dt class="col-sm-2">
+                @Html.DisplayNameFor(model => model.CreateDateTime)
+            </dt>
+            <dd class="col-sm-10">
+                @Html.DisplayFor(model => model.CreateDateTime)
+            </dd>
+            <dt class="col-sm-2">
+                @Html.DisplayNameFor(model => model.UserType.Name)
+            </dt>
+            <dd class="col-sm-10">
+                @Html.DisplayFor(model => model.UserType.Name)
+            </dd>
+        </dl>
+
+        <form asp-action="Delete">
+            <input type="submit" value="Deactivate" class="btn btn-danger" /> |
+            <a asp-action="Index">Back to List</a>
+        </form>
+    </div>
+</div>

--- a/TabloidMVC/Views/UserProfile/Index.cshtml
+++ b/TabloidMVC/Views/UserProfile/Index.cshtml
@@ -46,7 +46,7 @@
                         @*<a asp-action="Edit" asp-route-id="@item.Id" class="btn btn-outline-primary mx-1" title="Edit">
                             <i class="fas fa-pencil-alt"></i>
                         </a>*@
-                        <a asp-action="Delete" asp-route-id="@item.Id" class="btn btn-outline-primary mx-1" title="Delete">
+                        <a asp-action="Delete" asp-route-id="@item.Id" class="btn btn-outline-primary mx-1" title="Deactivate">
                             <i class="fas fa-trash"></i>
                         </a>
                     </td>

--- a/TabloidMVC/Views/UserProfile/Index.cshtml
+++ b/TabloidMVC/Views/UserProfile/Index.cshtml
@@ -45,10 +45,10 @@
                         </a>
                         @*<a asp-action="Edit" asp-route-id="@item.Id" class="btn btn-outline-primary mx-1" title="Edit">
                             <i class="fas fa-pencil-alt"></i>
-                        </a>
+                        </a>*@
                         <a asp-action="Delete" asp-route-id="@item.Id" class="btn btn-outline-primary mx-1" title="Delete">
                             <i class="fas fa-trash"></i>
-                        </a>*@
+                        </a>
                     </td>
                 </tr>
             }


### PR DESCRIPTION
### Changes:
- updated SQL startup scripts to include `IsDeactivated` column in `UserProfile` table
- added `Delete` actions to `UserProfileController`
- added deactivate method to `UserProfileRepository` and `IUserProfileRepository`
- added `UserProfile/Delete` view
- updated GetAll and GetByEmail methods in `UserProfileRepository` to only get active profiles
- added `GetDeactivated` method to `UserProfileRepository` to get deactivated profiles (to be used later)
- prevented deactivated users from logging in

---
### Testing:
- Fetch and run app
- Run the following SQL script to add a Test User
```
INSERT INTO UserProfile (DisplayName, FirstName, LastName, Email, CreateDateTime, ImageLocation, UserTypeId)
	VALUES ('Test2', 'Test2', 'Test2', 'test2@test.com', SYSDATETIME(), NULL, 1)
```	 
- log into app as an administrator (admin@example.com)
- click User Profiles in the navbar to view all active users (including your new user)
- select the Deactivate button next to the user Test2, and confirm deactivation
- the user profiles list should no longer list that user
- log out and try to log in with the test user you deactivated (test2@test.com). It shouldn't work.