### PR TITLE
Prevent Loss of Last Admin

### DIFF
--- a/TabloidMVC/Controllers/UserProfileController.cs
+++ b/TabloidMVC/Controllers/UserProfileController.cs
@@ -50,6 +50,10 @@ namespace TabloidMVC.Controllers
         public ActionResult Edit(int id)
         {
             UserProfile userToEdit = _userProfileRepository.GetById(id);
+            if (userToEdit == null)
+            {
+                return NotFound();
+            }
             int currentUserId = GetCurrentUserProfileId();
             UserProfile currentUser = _userProfileRepository.GetById(currentUserId);
             int adminCount = _userProfileRepository.GetAll().Where(up => up.UserTypeId == 1).ToList().Count;
@@ -60,7 +64,6 @@ namespace TabloidMVC.Controllers
                     UserTypes = _userProfileRepository.GetUserTypes(),
                     User = userToEdit,
                     AdminCount = adminCount,
-                    Message = null
                 };
                 return View(vm);
             }
@@ -107,12 +110,15 @@ namespace TabloidMVC.Controllers
             if (currentUser.UserTypeId == 1)
             {
                 UserProfile userToDelete = _userProfileRepository.GetById(id);
+                if (userToDelete == null)
+                {
+                    return NotFound();
+                }
                 int adminCount = _userProfileRepository.GetAll().Where(up => up.UserTypeId == 1).ToList().Count;
                 DeleteUserProfileViewModel vm = new DeleteUserProfileViewModel()
                 {
                     User = userToDelete,
                     AdminCount = adminCount,
-                    Message = null
                 };
 
                 return View(vm);

--- a/TabloidMVC/Models/ViewModels/ChangeUserTypeViewModel.cs
+++ b/TabloidMVC/Models/ViewModels/ChangeUserTypeViewModel.cs
@@ -9,5 +9,7 @@ namespace TabloidMVC.Models.ViewModels
     {
         public List<UserType> UserTypes { get; set; }
         public UserProfile User { get; set; }
+        public int AdminCount { get; set; }
+        public string Message { get; set; }
     }
 }

--- a/TabloidMVC/Models/ViewModels/DeleteUserProfileViewModel.cs
+++ b/TabloidMVC/Models/ViewModels/DeleteUserProfileViewModel.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace TabloidMVC.Models.ViewModels
+{
+    public class DeleteUserProfileViewModel
+    {
+        public UserProfile User { get; set; }
+        public int AdminCount { get; set; }
+        public string Message { get; set; }
+    }
+}

--- a/TabloidMVC/Views/Shared/_Layout.cshtml
+++ b/TabloidMVC/Views/Shared/_Layout.cshtml
@@ -30,6 +30,10 @@
                             <li class="nav-item mx-0 mx-lg-1">
                                 <a class="nav-link py-3 px-0 px-lg-3 rounded js-scroll-trigger" asp-area="" asp-controller="Post" asp-action="Index">POSTS</a>
                             </li>
+                        <li class="nav-item mx-0 mx-lg-1">
+                                <a class="nav-link py-3 px-0 px-lg-3 rounded js-scroll-trigger" asp-area="" asp-controller="Post" asp-action="MyPosts">MY POSTS</a>
+                            </li>
+
                             <li class="nav-item mx-0 mx-lg-1">
                                 <a class="nav-link py-3 px-0 px-lg-3 rounded js-scroll-trigger" asp-area="" asp-controller="Category" asp-action="Index">Category Management</a>
                             </li>

--- a/TabloidMVC/Views/UserProfile/Delete.cshtml
+++ b/TabloidMVC/Views/UserProfile/Delete.cshtml
@@ -1,48 +1,66 @@
-﻿@model TabloidMVC.Models.UserProfile
-
+﻿@model TabloidMVC.Models.ViewModels.DeleteUserProfileViewModel
 @{
-    ViewData["Title"] = "Delete";
+    ViewData["Title"] = "Deactivate User";
 }
-<div class="container mx-4 pt-5">
-    <h3>Are you sure you want to deactivate user <b>@Model.DisplayName</b>?</h3>
-    <div>
-        <hr />
-        <dl class="row">
-            <dt class="col-sm-2">
-                @Html.DisplayNameFor(model => model.DisplayName)
-            </dt>
-            <dd class="col-sm-10">
-                @Html.DisplayFor(model => model.DisplayName)
-            </dd>
-            <dt class="col-sm-2">
-                @Html.DisplayNameFor(model => model.FullName)
-            </dt>
-            <dd class="col-sm-10">
-                @Html.DisplayFor(model => model.FullName)
-            </dd>
-            <dt class="col-sm-2">
-                @Html.DisplayNameFor(model => model.Email)
-            </dt>
-            <dd class="col-sm-10">
-                @Html.DisplayFor(model => model.Email)
-            </dd>
-            <dt class="col-sm-2">
-                @Html.DisplayNameFor(model => model.CreateDateTime)
-            </dt>
-            <dd class="col-sm-10">
-                @Html.DisplayFor(model => model.CreateDateTime)
-            </dd>
-            <dt class="col-sm-2">
-                @Html.DisplayNameFor(model => model.UserType.Name)
-            </dt>
-            <dd class="col-sm-10">
-                @Html.DisplayFor(model => model.UserType.Name)
-            </dd>
-        </dl>
+@if (Model.Message == null)
+{
 
-        <form asp-action="Delete">
-            <input type="submit" value="Deactivate" class="btn btn-danger" /> |
-            <a asp-action="Index">Back to List</a>
-        </form>
+    <div class="container mx-4 pt-5">
+        <h3>Are you sure you want to deactivate user <b>@Model.User.DisplayName</b>?</h3>
+        <div>
+            <hr />
+            <dl class="row">
+                <dt class="col-sm-2">
+                    @Html.DisplayNameFor(model => model.User.DisplayName)
+                </dt>
+                <dd class="col-sm-10">
+                    @Html.DisplayFor(model => model.User.DisplayName)
+                </dd>
+                <dt class="col-sm-2">
+                    @Html.DisplayNameFor(model => model.User.FullName)
+                </dt>
+                <dd class="col-sm-10">
+                    @Html.DisplayFor(model => model.User.FullName)
+                </dd>
+                <dt class="col-sm-2">
+                    @Html.DisplayNameFor(model => model.User.Email)
+                </dt>
+                <dd class="col-sm-10">
+                    @Html.DisplayFor(model => model.User.Email)
+                </dd>
+                <dt class="col-sm-2">
+                    @Html.DisplayNameFor(model => model.User.CreateDateTime)
+                </dt>
+                <dd class="col-sm-10">
+                    @Html.DisplayFor(model => model.User.CreateDateTime)
+                </dd>
+                <dt class="col-sm-2">
+                    @Html.DisplayNameFor(model => model.User.UserType.Name)
+                </dt>
+                <dd class="col-sm-10">
+                    @Html.DisplayFor(model => model.User.UserType.Name)
+                </dd>
+            </dl>
+
+            <form asp-action="Delete">
+                <input type="hidden" asp-for="User.UserTypeId" value=@Model.User.UserTypeId />
+                <input type="hidden" asp-for="AdminCount" value=@Model.AdminCount />
+                <input type="submit" value="Deactivate" class="btn btn-danger" /> |
+                <a asp-action="Index">Back to List</a>
+            </form>
+        </div>
     </div>
-</div>
+}
+else
+{
+    <div class="container pt-5">
+        <div class="alert alert-danger">
+            @Model.Message
+        </div>
+        <div class="text-center mb-2">
+            <a asp-action="Index">Back to List</a>
+        </div>
+
+    </div>
+}
+

--- a/TabloidMVC/Views/UserProfile/Edit.cshtml
+++ b/TabloidMVC/Views/UserProfile/Edit.cshtml
@@ -3,32 +3,49 @@
 @{
     ViewData["Title"] = "Change User Role";
 }
-<div class="container pt-5">
-    <div class="row justify-content-center">
-        <div class="card col-md-8 pt-3">
-            <h4 class="text-center">Change Role of User "@Model.User.DisplayName"</h4>
-            <form asp-action="Edit">
-                <div asp-validation-summary="ModelOnly" class="text-danger"></div>
-                <input type="hidden" asp-for="User.Id" value=@Model.User.Id />
-                <div class="form-group">
-                    <label asp-for="User.UserTypeId" class="control-label">User Type</label>
-                    <select asp-for="User.UserTypeId" class="form-control">
-                        @foreach (UserType type in Model.UserTypes)
-                        {
-                            <option value="@type.Id">@type.Name</option>
-                        }
-                    </select>
+@if (Model.Message == null)
+{
+    <div class="container pt-5">
+        <div class="row justify-content-center">
+            <div class="card col-md-8 pt-3">
+                <h4 class="text-center">Change Role of User "@Model.User.DisplayName"</h4>
+                <form asp-action="Edit">
+                    <div asp-validation-summary="ModelOnly" class="text-danger"></div>
+                    <input type="hidden" asp-for="User.Id" value=@Model.User.Id />
+                    <input type="hidden" asp-for="AdminCount" value=@Model.AdminCount />
+                    <div class="form-group">
+                        <label asp-for="User.UserTypeId" class="control-label">User Type</label>
+                        <select asp-for="User.UserTypeId" class="form-control">
+                            @foreach (UserType type in Model.UserTypes)
+                            {
+                                <option value="@type.Id">@type.Name</option>
+                            }
+                        </select>
+                    </div>
+                    <div class="form-group">
+                        <input type="submit" value="Save" class="btn btn-primary" />
+                    </div>
+                </form>
+                <div class="text-center mb-2">
+                    <a asp-action="Index">Back to List</a>
                 </div>
-                <div class="form-group">
-                    <input type="submit" value="Save" class="btn btn-primary" />
-                </div>
-            </form>
-    <div class="text-center mb-2">
-        <a asp-action="Index">Back to List</a>
-    </div>
+            </div>
         </div>
     </div>
-</div>
+
+}
+else
+{
+    <div class="container pt-5">
+        <div class="alert alert-danger">
+            @Model.Message
+        </div>
+        <div class="text-center mb-2">
+            <a asp-action="Index">Back to List</a>
+        </div>
+
+    </div>
+}
 
 
 @section Scripts {

--- a/TabloidMVC/Views/UserProfile/Index.cshtml
+++ b/TabloidMVC/Views/UserProfile/Index.cshtml
@@ -55,3 +55,4 @@
         </tbody>
     </table>
 </div>
+


### PR DESCRIPTION
### Changes: 
- updated Edit and Delete methods/actions in `UserProfileController` to use view models which enable conditional display of error messages
- refactored Edit and Delete Views for UserProfiles to accept the new view models and display error messages
- added logic to prevent deletion or role reassignment of sole administrator
---
### Testing:
- Fetch branch and run app
- Log in as an administrator (admin@example.com) and navigate to UserProfile list
- Note how many users are admins and authors. If there is only one admin, try deleting and/or editing their user type. It shouldn't work
- Edit another user's type or delete another user to see that those actions still work